### PR TITLE
Use Ansible's default modules path

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Role Variables
 
 You can configure the module install directory by changing the value of `library_path` in `defaults/main.yml`. 
 
-The default install location is set to `/usr/share/my_modules/`.
+The default install location is set to `/usr/share/ansible/plugins/modules`.
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,4 +3,4 @@
 
 # Change this value to change the install location, otherwise we'll use what's
 # set in ansible.cfg
-library_path: /usr/share/my_modules/
+library_path: /usr/share/ansible/plugins/modules


### PR DESCRIPTION
This PR changes the default install directory for this module to Ansible's default system module path `/usr/share/ansible/plugins/modules`. That way there's no need to add an `ansible.cfg` entry, the new module should just work.